### PR TITLE
Enable node dragging in dependency graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,6 @@
 
 A simple way to visualize stale dependencies in the tscircuit ecosystem of packages.
 
+Nodes can be dragged around to customize the view.
+
 ![image](https://github.com/user-attachments/assets/d89099a9-39b7-4174-ba2f-59611c51367a)

--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "react-dom": "18",
         "react-hook-form": "^7.54.1",
         "react-resizable-panels": "^2.1.7",
-        "reactflow": "latest",
+        "reactflow": "^11.11.4",
         "recharts": "2.15.0",
         "semver": "latest",
         "sonner": "^1.7.1",

--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -1,7 +1,19 @@
 "use client"
 
 import { useCallback, useEffect, useState } from "react"
-import ReactFlow, { Controls, Background, addEdge, type Connection, type Edge, type Node, Panel } from "reactflow"
+import ReactFlow, {
+  Controls,
+  Background,
+  addEdge,
+  applyEdgeChanges,
+  applyNodeChanges,
+  type Connection,
+  type Edge,
+  type EdgeChange,
+  type Node,
+  type NodeChange,
+  Panel,
+} from "reactflow"
 import "reactflow/dist/style.css"
 import dagre from "dagre"
 
@@ -107,6 +119,18 @@ export function DependencyGraph() {
 
   const onConnect = useCallback((params: Connection | Edge) => setEdges((eds) => addEdge(params, eds)), [])
 
+  const onNodesChange = useCallback(
+    (changes: NodeChange[]) =>
+      setNodes((nds) => applyNodeChanges(changes, nds)),
+    [],
+  )
+
+  const onEdgesChange = useCallback(
+    (changes: EdgeChange[]) =>
+      setEdges((eds) => applyEdgeChanges(changes, eds)),
+    [],
+  )
+
   if (isLoading && nodes.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-screen">
@@ -151,8 +175,8 @@ export function DependencyGraph() {
         <ReactFlow
           nodes={nodes}
           edges={edges}
-          onNodesChange={() => {}}
-          onEdgesChange={() => {}}
+          onNodesChange={onNodesChange}
+          onEdgesChange={onEdgesChange}
           onConnect={onConnect}
           nodeTypes={nodeTypes}
           fitView

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-dom": "18",
     "react-hook-form": "^7.54.1",
     "react-resizable-panels": "^2.1.7",
-    "reactflow": "latest",
+    "reactflow": "^11.11.4",
     "recharts": "2.15.0",
     "semver": "latest",
     "sonner": "^1.7.1",


### PR DESCRIPTION
## Summary
- allow nodes and edges to update on change so they can be dragged
- note in README that nodes are draggable
- update reactflow to the latest version

## Testing
- `bun update --latest reactflow`
- `bun install`
- `bun test`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855d16c9fac832ea524e493f1ae6485