### PR TITLE
Enhance dependency edge display

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -213,12 +213,26 @@ export async function fetchDependencyGraphData(repoUrls: string[]): Promise<Grap
           // If the dependency is one of the tracked packages
           const sourceNodeExists = fetchedRepos.some((r) => r.packageName === depName && !r.error) // Ensure source node (the dependency) exists and is valid
           if (sourceNodeExists) {
+            const requiredVersionRange = allDependencies[depName]
+            const latestAvailableVersion = latestVersionsMap.get(depName)!
+            const isLatest = semver.satisfies(
+              latestAvailableVersion,
+              requiredVersionRange,
+            )
             edges.push({
               id: `e-${depName}-${nodeId}`, // Edge from dependency to current repo
               source: depName, // Source is the dependency package name
               target: nodeId, // Target is the current repo's ID (packageName or fallback)
-              label: allDependencies[depName], // Show required version range on edge
+              label: isLatest
+                ? requiredVersionRange
+                : `${requiredVersionRange} / ${latestAvailableVersion}`,
               animated: status === "STALE_DEPENDENCY", // Animate if the current repo (target) is stale
+              style: {
+                stroke: isLatest ? "#9ca3af" : "#eab308",
+              },
+              labelStyle: {
+                fill: isLatest ? "#9ca3af" : "#eab308",
+              },
             })
           }
         }

--- a/bun.lock
+++ b/bun.lock
@@ -50,7 +50,7 @@
         "react-resizable-panels": "^2.1.7",
         "reactflow": "latest",
         "recharts": "2.15.0",
-        "semver": "latest",
+        "semver": "^7.7.2",
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "react-resizable-panels": "^2.1.7",
     "reactflow": "latest",
     "recharts": "2.15.0",
-    "semver": "latest",
+    "semver": "^7.7.2",
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",


### PR DESCRIPTION
## Summary
- show edges in gray when dependency requirement satisfies the latest version
- show edges in yellow with `used / latest` label when dependency is behind
- update semver package

## Testing
- `bun update --latest semver`
- `bun run format` *(fails: Script not found)*
- `bun test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_6855d30fb374832e83116cf95de363ef