### PR TITLE
Update metadata and repo list

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import './globals.css'
 
 export const metadata: Metadata = {
   title: 'tscircuit Dependency Graph',
-  description: 'Created with v0',
+  description: 'Visualize tscircuit package dependencies',
   generator: 'v0.dev',
 }
 

--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -19,6 +19,7 @@ const REPO_URLS = [
   "https://github.com/tscircuit/pcb-viewer",
   "https://github.com/tscircuit/circuit-json",
   "https://github.com/tscircuit/props",
+  "https://github.com/tscircuit/tscircuit-autorouter",
 ]
 
 const nodeTypes = {


### PR DESCRIPTION
## Summary
- update site description to remove the v0 reference
- include `tscircuit-autorouter` repo in the dependency graph

## Testing
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855d1601e60832e9442505808d9b271