### PR TITLE
Enhance stale dependency labels

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -2,6 +2,7 @@
 
 import type { Node, Edge } from "reactflow"
 import semver from "semver"
+import { formatEdgeLabel } from "../lib/formatEdgeLabel"
 
 const GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com"
 
@@ -75,16 +76,6 @@ function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
   return null
 }
 
-export function formatEdgeLabel(
-  depName: string,
-  requiredRange: string,
-  latestVersion: string,
-  isLatest: boolean,
-): string {
-  return isLatest
-    ? requiredRange
-    : `${depName}\n${requiredRange} / ${latestVersion}`
-}
 
 async function fetchLastPackageJsonUpdate(
   owner: string,

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -75,6 +75,17 @@ function parseGitHubUrl(url: string): { owner: string; repo: string } | null {
   return null
 }
 
+export function formatEdgeLabel(
+  depName: string,
+  requiredRange: string,
+  latestVersion: string,
+  isLatest: boolean,
+): string {
+  return isLatest
+    ? requiredRange
+    : `${depName}\n${requiredRange} / ${latestVersion}`
+}
+
 async function fetchLastPackageJsonUpdate(
   owner: string,
   repo: string,
@@ -223,9 +234,12 @@ export async function fetchDependencyGraphData(repoUrls: string[]): Promise<Grap
               id: `e-${depName}-${nodeId}`, // Edge from dependency to current repo
               source: depName, // Source is the dependency package name
               target: nodeId, // Target is the current repo's ID (packageName or fallback)
-              label: isLatest
-                ? requiredVersionRange
-                : `${requiredVersionRange} / ${latestAvailableVersion}`,
+              label: formatEdgeLabel(
+                depName,
+                requiredVersionRange,
+                latestAvailableVersion,
+                isLatest,
+              ),
               animated: status === "STALE_DEPENDENCY", // Animate if the current repo (target) is stale
               style: {
                 stroke: isLatest ? "#9ca3af" : "#eab308",

--- a/lib/formatEdgeLabel.ts
+++ b/lib/formatEdgeLabel.ts
@@ -1,0 +1,10 @@
+export function formatEdgeLabel(
+  depName: string,
+  requiredRange: string,
+  latestVersion: string,
+  isLatest: boolean,
+): string {
+  return isLatest
+    ? requiredRange
+    : `${depName}\n${requiredRange} / ${latestVersion}`
+}

--- a/tests/formatEdgeLabel.test.ts
+++ b/tests/formatEdgeLabel.test.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "bun:test";
+import { formatEdgeLabel } from "../app/actions";
+
+test("adds dependency name when not latest", () => {
+  const label = formatEdgeLabel("@tscircuit/core", "1.2.0", "1.3.0", false);
+  expect(label).toBe("@tscircuit/core\n1.2.0 / 1.3.0");
+});
+
+test("returns range when up to date", () => {
+  const label = formatEdgeLabel("@tscircuit/core", "1.3.0", "1.3.0", true);
+  expect(label).toBe("1.3.0");
+});

--- a/tests/formatEdgeLabel.test.ts
+++ b/tests/formatEdgeLabel.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test";
-import { formatEdgeLabel } from "../app/actions";
+import { formatEdgeLabel } from "../lib/formatEdgeLabel";
 
 test("adds dependency name when not latest", () => {
   const label = formatEdgeLabel("@tscircuit/core", "1.2.0", "1.3.0", false);


### PR DESCRIPTION
## Summary
- display dependency name in edge labels when a package version is stale
- expose `formatEdgeLabel` helper
- add tests for `formatEdgeLabel`

## Testing
- `bun test tests/formatEdgeLabel.test.ts`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855ebb69d4c832e9579d0124d6ac768