### PR TITLE
Implement edge color logic for version age

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,6 +3,7 @@
 import type { Node, Edge } from "reactflow"
 import semver from "semver"
 import { formatEdgeLabel } from "../lib/formatEdgeLabel"
+import { getEdgeColor } from "../lib/getEdgeColor"
 
 const GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com"
 
@@ -221,6 +222,10 @@ export async function fetchDependencyGraphData(repoUrls: string[]): Promise<Grap
               latestAvailableVersion,
               requiredVersionRange,
             )
+            const color = getEdgeColor(
+              requiredVersionRange,
+              latestAvailableVersion,
+            )
             edges.push({
               id: `e-${depName}-${nodeId}`, // Edge from dependency to current repo
               source: depName, // Source is the dependency package name
@@ -233,10 +238,10 @@ export async function fetchDependencyGraphData(repoUrls: string[]): Promise<Grap
               ),
               animated: status === "STALE_DEPENDENCY", // Animate if the current repo (target) is stale
               style: {
-                stroke: isLatest ? "#9ca3af" : "#eab308",
+                stroke: color,
               },
               labelStyle: {
-                fill: isLatest ? "#9ca3af" : "#eab308",
+                fill: color,
               },
             })
           }

--- a/lib/getEdgeColor.ts
+++ b/lib/getEdgeColor.ts
@@ -1,0 +1,24 @@
+import semver from "semver";
+
+export function getEdgeColor(requiredRange: string, latestVersion: string): string {
+  const latest = semver.parse(latestVersion);
+  const required = semver.minVersion(requiredRange);
+  if (!latest || !required) return "#eab308"; // default yellow/orange
+
+  if (semver.eq(required, latest)) {
+    return "#3b82f6"; // blue for latest
+  }
+
+  if (latest.major !== required.major || latest.minor !== required.minor) {
+    return "#ef4444"; // red if minor/major mismatch
+  }
+
+  const patchDiff = latest.patch - required.patch;
+  if (patchDiff > 20) {
+    return "#ef4444"; // red if >20 patch versions
+  }
+  if (patchDiff > 2) {
+    return "#eab308"; // orange/yellow
+  }
+  return "#9ca3af"; // gray when within 2 patches
+}

--- a/tests/getEdgeColor.test.ts
+++ b/tests/getEdgeColor.test.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "bun:test";
+import { getEdgeColor } from "../lib/getEdgeColor";
+
+test("returns blue when versions match", () => {
+  expect(getEdgeColor("1.0.0", "1.0.0")).toBe("#3b82f6");
+});
+
+test("returns gray when within 2 patch versions", () => {
+  expect(getEdgeColor("1.0.0", "1.0.2")).toBe("#9ca3af");
+});
+
+test("returns orange when between 2 and 20 patch versions", () => {
+  expect(getEdgeColor("1.0.0", "1.0.10")).toBe("#eab308");
+});
+
+test("returns red when minor version differs", () => {
+  expect(getEdgeColor("1.0.0", "1.1.0")).toBe("#ef4444");
+});
+
+test("returns red when patch diff over 20", () => {
+  expect(getEdgeColor("1.0.0", "1.0.30")).toBe("#ef4444");
+});


### PR DESCRIPTION
## Summary
- add `getEdgeColor` helper to compute color from version difference
- use `getEdgeColor` when building dependency edges
- test new color logic

## Testing
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855f0c1b3f8832ea7c2d766f039392e