### PR TITLE
Add section-based layout

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -3,32 +3,9 @@
 import type { Node, Edge } from "reactflow"
 import semver from "semver"
 import { formatEdgeLabel } from "../lib/formatEdgeLabel"
+import { getSectionForPackage } from "../lib/sections"
 
 const GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com"
-
-export const PACKAGE_SECTION_MAP: Record<string, string> = {
-  "circuit-json": "Specifications",
-  "@tscircuit/props": "Specifications",
-  "schematic-symbols": "Specifications",
-  "@tscircuit/footprinter": "Specifications",
-  "jscad-fiber": "Specifications",
-  "circuit-to-svg": "Core Utility",
-  "jscad-electronics": "Core Utility",
-  "@tscircuit/core": "Core",
-  "@tscircuit/schematic-viewer": "UI Packages",
-  "@tscircuit/pcb-viewer": "UI Packages",
-  "@tscircuit/3d-viewer": "UI Packages",
-  "@tscircuit/eval": "Packaged Bundles",
-  "@tscircuit/runframe": "Packaged Bundles",
-}
-
-export function getSectionForPackage(pkg: string, repo: string): string {
-  return (
-    PACKAGE_SECTION_MAP[pkg] ||
-    PACKAGE_SECTION_MAP[repo] ||
-    "Downstream"
-  )
-}
 
 export interface DisplayNodeData {
   label: string // package name for display

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -6,6 +6,30 @@ import { formatEdgeLabel } from "../lib/formatEdgeLabel"
 
 const GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com"
 
+export const PACKAGE_SECTION_MAP: Record<string, string> = {
+  "circuit-json": "Specifications",
+  "@tscircuit/props": "Specifications",
+  "schematic-symbols": "Specifications",
+  "@tscircuit/footprinter": "Specifications",
+  "jscad-fiber": "Specifications",
+  "circuit-to-svg": "Core Utility",
+  "jscad-electronics": "Core Utility",
+  "@tscircuit/core": "Core",
+  "@tscircuit/schematic-viewer": "UI Packages",
+  "@tscircuit/pcb-viewer": "UI Packages",
+  "@tscircuit/3d-viewer": "UI Packages",
+  "@tscircuit/eval": "Packaged Bundles",
+  "@tscircuit/runframe": "Packaged Bundles",
+}
+
+export function getSectionForPackage(pkg: string, repo: string): string {
+  return (
+    PACKAGE_SECTION_MAP[pkg] ||
+    PACKAGE_SECTION_MAP[repo] ||
+    "Downstream"
+  )
+}
+
 export interface DisplayNodeData {
   label: string // package name for display
   version: string // its own current version
@@ -15,6 +39,7 @@ export interface DisplayNodeData {
   error?: string // Error message if status is ERROR
   repoName: string // Extracted repository name
   packageJsonLastUpdated?: string // ISO timestamp of last package.json commit
+  section: string
 }
 
 export interface GraphData {
@@ -204,6 +229,10 @@ export async function fetchDependencyGraphData(repoUrls: string[]): Promise<Grap
         packageJsonLastUpdated: repo.packageJsonLastUpdated,
         error: nodeError,
         repoName: repo.repoName,
+        section: getSectionForPackage(
+          repo.packageName || repo.repoName,
+          repo.repoName,
+        ),
       },
     })
 

--- a/components/section-node.tsx
+++ b/components/section-node.tsx
@@ -1,0 +1,15 @@
+"use client"
+
+import type { NodeProps } from "reactflow"
+
+export interface SectionNodeData {
+  label: string
+}
+
+export function SectionNode({ data }: NodeProps<SectionNodeData>) {
+  return (
+    <div className="px-3 py-1 rounded-md bg-gray-200 dark:bg-gray-700 shadow text-sm font-semibold text-center">
+      {data.label}
+    </div>
+  )
+}

--- a/lib/sections.ts
+++ b/lib/sections.ts
@@ -1,0 +1,23 @@
+export const PACKAGE_SECTION_MAP: Record<string, string> = {
+  "circuit-json": "Specifications",
+  "@tscircuit/props": "Specifications",
+  "schematic-symbols": "Specifications",
+  "@tscircuit/footprinter": "Specifications",
+  "jscad-fiber": "Specifications",
+  "circuit-to-svg": "Core Utility",
+  "jscad-electronics": "Core Utility",
+  "@tscircuit/core": "Core",
+  "@tscircuit/schematic-viewer": "UI Packages",
+  "@tscircuit/pcb-viewer": "UI Packages",
+  "@tscircuit/3d-viewer": "UI Packages",
+  "@tscircuit/eval": "Packaged Bundles",
+  "@tscircuit/runframe": "Packaged Bundles",
+}
+
+export function getSectionForPackage(pkg: string, repo: string): string {
+  return (
+    PACKAGE_SECTION_MAP[pkg] ||
+    PACKAGE_SECTION_MAP[repo] ||
+    "Downstream"
+  )
+}

--- a/tests/getSectionForPackage.test.ts
+++ b/tests/getSectionForPackage.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "bun:test"
-import { getSectionForPackage } from "../app/actions"
+import { getSectionForPackage } from "../lib/sections"
 
 const cases: [string, string][] = [
   ["circuit-json", "Specifications"],

--- a/tests/getSectionForPackage.test.ts
+++ b/tests/getSectionForPackage.test.ts
@@ -1,0 +1,16 @@
+import { expect, test } from "bun:test"
+import { getSectionForPackage } from "../app/actions"
+
+const cases: [string, string][] = [
+  ["circuit-json", "Specifications"],
+  ["@tscircuit/core", "Core"],
+  ["@tscircuit/pcb-viewer", "UI Packages"],
+  ["@tscircuit/eval", "Packaged Bundles"],
+  ["unknown-package", "Downstream"],
+]
+
+for (const [pkg, section] of cases) {
+  test(`section for ${pkg}`, () => {
+    expect(getSectionForPackage(pkg, pkg)).toBe(section)
+  })
+}


### PR DESCRIPTION
## Summary
- categorize repos by section and expose helper to lookup sections
- include footprinter repo in graph
- show section labels and group repos by section in layout
- add SectionNode component
- test section helpers

## Testing
- `bun run format` *(fails: Script not found)*
- `bun test tests`

------
https://chatgpt.com/codex/tasks/task_b_6855f3249138832e835236b56a5a327a