### PR TITLE
Color nodes based on incoming edges

### DIFF
--- a/components/custom-graph-node.tsx
+++ b/components/custom-graph-node.tsx
@@ -41,8 +41,13 @@ export function CustomGraphNode({ data }: NodeProps<DisplayNodeData>) {
       statusColorClass = "border-green-500"
       break
     case "STALE_DEPENDENCY":
-      statusIcon = <LoadingSpinner className="h-5 w-5 text-yellow-500" />
-      statusColorClass = "border-yellow-500"
+      if (data.worstEdgeColor === "#ef4444") {
+        statusIcon = <LoadingSpinner className="h-5 w-5 text-red-500" />
+        statusColorClass = "border-red-500"
+      } else {
+        statusIcon = <LoadingSpinner className="h-5 w-5 text-yellow-500" />
+        statusColorClass = "border-yellow-500"
+      }
       break
     case "ERROR":
       statusIcon = <XCircle className="h-5 w-5 text-red-500" />


### PR DESCRIPTION
## Summary
- add `worstEdgeColor` to `DisplayNodeData`
- compute worst incoming edge color when building the graph
- show red or yellow node borders depending on the worst incoming edge

## Testing
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855f3b22338832eb0c89ad562914ca7