### PR TITLE
Respect peerDependencies when creating edges

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -101,7 +101,10 @@ async function fetchLastPackageJsonUpdate(
   return null
 }
 
-export async function fetchDependencyGraphData(repoUrls: string[]): Promise<GraphData> {
+export async function fetchDependencyGraphData(
+  repoUrls: string[],
+  onlyPeerDependencies = true,
+): Promise<GraphData> {
   const fetchedRepos: FetchedRepoInfo[] = await Promise.all(
     repoUrls.map(async (url) => {
       const parsed = parseGitHubUrl(url)
@@ -216,8 +219,9 @@ export async function fetchDependencyGraphData(repoUrls: string[]): Promise<Grap
       const allDependencies = { ...repo.dependencies, ...repo.devDependencies }
       const peerDeps = repo.peerDependencies || {}
       for (const depName in allDependencies) {
-        if (latestVersionsMap.has(depName) && depName in peerDeps) {
-          // If the dependency is one of the tracked packages and declared as a peer dependency
+        const included = onlyPeerDependencies ? depName in peerDeps : true
+        if (latestVersionsMap.has(depName) && included) {
+          // If the dependency is one of the tracked packages and meets the filter
           const sourceNodeExists = fetchedRepos.some(
             (r) => r.packageName === depName && !r.error,
           ) // Ensure source node (the dependency) exists and is valid

--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -22,6 +22,13 @@ import { CustomGraphNode } from "./custom-graph-node"
 import { Button } from "@/components/ui/button"
 import { RefreshCw, LayoutDashboard } from "lucide-react"
 import { LoadingSpinner } from "./loading-spinner"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
 
 const REPO_URLS = [
   "https://github.com/tscircuit/tscircuit",
@@ -99,6 +106,7 @@ export function DependencyGraph() {
   const [error, setError] = useState<string | null>(null)
   const [userHasMovedNodes, setUserHasMovedNodes] = useState(false)
   const lastLayoutNodeIds = useRef<Set<string>>(new Set())
+  const [dependencyMode, setDependencyMode] = useState<"peer" | "all">("peer")
 
   const fetchData = useCallback(
     async (isInitialLoad = false) => {
@@ -106,7 +114,10 @@ export function DependencyGraph() {
       setIsLayouting(true)
       setError(null)
       try {
-        const data: GraphData = await fetchDependencyGraphData(REPO_URLS)
+        const data: GraphData = await fetchDependencyGraphData(
+          REPO_URLS,
+          dependencyMode === "peer",
+        )
         const { nodes: layoutedNodes, edges: layoutedEdges } = getLayoutedElements(
           data.nodes,
           data.edges,
@@ -137,7 +148,7 @@ export function DependencyGraph() {
         setIsLayouting(false)
       }
     },
-    [userHasMovedNodes],
+    [userHasMovedNodes, dependencyMode],
   )
 
   useEffect(() => {
@@ -198,6 +209,18 @@ export function DependencyGraph() {
           )}
         </div>
         <div className="flex items-center gap-2">
+          <Select
+            value={dependencyMode}
+            onValueChange={(v) => setDependencyMode(v as "peer" | "all")}
+          >
+            <SelectTrigger className="w-40 bg-background text-foreground">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="peer">Peer Dependencies</SelectItem>
+              <SelectItem value="all">Any Dependency</SelectItem>
+            </SelectContent>
+          </Select>
           <a
             href="https://github.com/tscircuit/deps.tscircuit.com"
             target="_blank"


### PR DESCRIPTION
## Summary
- add `peerDependencies` to `FetchedRepoInfo`
- only create dependency edges when the dependency is also declared in `peerDependencies`

## Testing
- `bun test tests`
- `bun run format` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855f6b56ce0832eaaf9c288cf7f01b3