### PR TITLE
Add node focus toggle

### DIFF
--- a/components/custom-graph-node.tsx
+++ b/components/custom-graph-node.tsx
@@ -7,6 +7,10 @@ import { Button } from "@/components/ui/button"
 import { CheckCircle2, ExternalLink, XCircle } from "lucide-react"
 import { LoadingSpinner } from "./loading-spinner"
 import type { DisplayNodeData } from "@/app/actions" // Ensure this path is correct
+
+interface GraphNodeData extends DisplayNodeData {
+  onFocus?: (id: string) => void
+}
 import { useEffect, useState } from "react"
 
 function formatTimeAgo(dateString: string) {
@@ -19,7 +23,7 @@ function formatTimeAgo(dateString: string) {
   return `${days}d`
 }
 
-export function CustomGraphNode({ data }: NodeProps<DisplayNodeData>) {
+export function CustomGraphNode({ data, id }: NodeProps<GraphNodeData>) {
   let statusIcon
   let statusColorClass = ""
 
@@ -89,9 +93,17 @@ export function CustomGraphNode({ data }: NodeProps<DisplayNodeData>) {
             GitHub <ExternalLink className="ml-1 h-3 w-3" />
           </a>
         </Button>
-        {data.packageJsonLastUpdated && (
-          <span className="text-xs text-muted-foreground">Last Update: {timeAgo}</span>
-        )}
+        <div className="flex items-center gap-2">
+          {data.packageJsonLastUpdated && (
+            <span className="text-xs text-muted-foreground">Last Update: {timeAgo}</span>
+          )}
+          <button
+            onClick={() => data.onFocus?.(id)}
+            className="text-xs text-blue-500 underline"
+          >
+            Focus
+          </button>
+        </div>
       </CardFooter>
       <Handle type="source" position={Position.Bottom} className="!bg-slate-500" />
     </Card>

--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useCallback, useEffect, useState, useRef } from "react"
+import { useCallback, useEffect, useState, useRef, useMemo } from "react"
 import ReactFlow, {
   Controls,
   Background,
@@ -209,6 +209,19 @@ export function DependencyGraph() {
     ? edges.filter((e) => e.source === focusedNodeId || e.target === focusedNodeId)
     : edges
 
+  const displayNodes = useMemo(() => {
+    if (!focusedNodeId) return nodes
+    const connected = new Set<string>([focusedNodeId])
+    edges.forEach((e) => {
+      if (e.source === focusedNodeId) connected.add(e.target)
+      if (e.target === focusedNodeId) connected.add(e.source)
+    })
+    return nodes.map((node) => ({
+      ...node,
+      style: { ...(node.style || {}), opacity: connected.has(node.id) ? 1 : 0.5 },
+    }))
+  }, [nodes, edges, focusedNodeId])
+
   if (isLoading && nodes.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center h-screen">
@@ -281,7 +294,7 @@ export function DependencyGraph() {
               size="sm"
               className="bg-background text-foreground hover:bg-accent"
             >
-              Clear Focus
+              Unfocus
             </Button>
           )}
         </div>
@@ -296,7 +309,7 @@ export function DependencyGraph() {
       )}
       <div className="flex-grow">
         <ReactFlow
-          nodes={nodes}
+          nodes={displayNodes}
           edges={displayEdges}
           onNodesChange={onNodesChange}
           onEdgesChange={onEdgesChange}


### PR DESCRIPTION
## Summary
- extend graph node data with optional onFocus callback
- add Focus control in each node card
- filter edges by focused node and support clearing focus

## Testing
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6855fc258c50832e92d6874cff9f4413