### PR TITLE
Update category mapping for tscircuit

### DIFF
--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -115,7 +115,9 @@ export function DependencyGraph() {
   const lastLayoutNodeIds = useRef<Set<string>>(new Set())
   const [dependencyMode, setDependencyMode] = useState<"peer" | "all">("peer")
   const [visibleCategories, setVisibleCategories] = useState<string[]>(
-    ALL_CATEGORIES.filter((c) => c !== "Downstream"),
+    ALL_CATEGORIES.filter(
+      (c) => c !== "Downstream" && c !== "UI Packages",
+    ),
   )
 
   const fetchData = useCallback(

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -5,13 +5,14 @@ export const PACKAGE_CATEGORY_MAP: Record<string, string> = {
   "@tscircuit/footprinter": "Specifications",
   "jscad-fiber": "Specifications",
   "circuit-to-svg": "Core Utility",
-  "jscad-electronics": "Core Utility",
+  "jscad-electronics": "UI Packages",
   "@tscircuit/core": "Core",
   "@tscircuit/schematic-viewer": "UI Packages",
   "@tscircuit/pcb-viewer": "UI Packages",
   "@tscircuit/3d-viewer": "UI Packages",
   "@tscircuit/eval": "Packaged Bundles",
   "@tscircuit/runframe": "Packaged Bundles",
+  tscircuit: "Packaged Bundles",
 }
 
 export const ALL_CATEGORIES = [

--- a/tests/getCategoryForPackage.test.ts
+++ b/tests/getCategoryForPackage.test.ts
@@ -5,6 +5,16 @@ test("returns mapped category", () => {
   expect(getCategoryForPackage("circuit-json", "circuit-json")).toBe("Specifications")
 })
 
+test("maps jscad-electronics to UI Packages", () => {
+  expect(getCategoryForPackage("jscad-electronics", "jscad-electronics")).toBe(
+    "UI Packages",
+  )
+})
+
+test("maps tscircuit to Packaged Bundles", () => {
+  expect(getCategoryForPackage("tscircuit", "tscircuit")).toBe("Packaged Bundles")
+})
+
 test("falls back to repo name", () => {
   expect(getCategoryForPackage("unknown", "@tscircuit/core")).toBe("Core")
 })


### PR DESCRIPTION
## Summary
- mark `tscircuit` as a Packaged Bundle
- test the new category mapping

## Testing
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_68560a557130832eba69ca54fac30d8b