### PR TITLE
Add parts-engine core util repo

### DIFF
--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -55,6 +55,7 @@ const REPO_URLS = [
   "https://github.com/tscircuit/schematic-symbols",
   "https://github.com/tscircuit/jscad-fiber",
   "https://github.com/tscircuit/jscad-electronics",
+  "https://github.com/tscircuit/parts-engine",
 ]
 
 const nodeTypes = {

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -12,6 +12,8 @@ export const PACKAGE_CATEGORY_MAP: Record<string, string> = {
   "@tscircuit/3d-viewer": "UI Packages",
   "@tscircuit/eval": "Packaged Bundles",
   "@tscircuit/runframe": "Packaged Bundles",
+  "@tscircuit/parts-engine": "Core Utility",
+  "parts-engine": "Core Utility",
   tscircuit: "Packaged Bundles",
 }
 

--- a/tests/getCategoryForPackage.test.ts
+++ b/tests/getCategoryForPackage.test.ts
@@ -11,6 +11,12 @@ test("maps jscad-electronics to UI Packages", () => {
   )
 })
 
+test("maps parts-engine to Core Utility", () => {
+  expect(
+    getCategoryForPackage("@tscircuit/parts-engine", "parts-engine"),
+  ).toBe("Core Utility")
+})
+
 test("maps tscircuit to Packaged Bundles", () => {
   expect(getCategoryForPackage("tscircuit", "tscircuit")).toBe("Packaged Bundles")
 })


### PR DESCRIPTION
## Summary
- track `parts-engine` repo in the dependency graph
- categorize `@tscircuit/parts-engine` as a **Core Utility**
- test the new category mapping

## Testing
- `bun test tests/getCategoryForPackage.test.ts`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_68562c0b8748832e8191daf8460c186b