### PR TITLE
Add tscircuit checks to category map

### DIFF
--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -14,6 +14,7 @@ export const PACKAGE_CATEGORY_MAP: Record<string, string> = {
   "@tscircuit/runframe": "Packaged Bundles",
   "@tscircuit/parts-engine": "Core Utility",
   "parts-engine": "Core Utility",
+  "tscircuit/checks": "Core Utility",
   tscircuit: "Packaged Bundles",
 }
 

--- a/tests/getCategoryForPackage.test.ts
+++ b/tests/getCategoryForPackage.test.ts
@@ -17,6 +17,12 @@ test("maps parts-engine to Core Utility", () => {
   ).toBe("Core Utility")
 })
 
+test("maps tscircuit/checks to Core Utility", () => {
+  expect(
+    getCategoryForPackage("tscircuit/checks", "tscircuit/checks"),
+  ).toBe("Core Utility")
+})
+
 test("maps tscircuit to Packaged Bundles", () => {
   expect(getCategoryForPackage("tscircuit", "tscircuit")).toBe("Packaged Bundles")
 })


### PR DESCRIPTION
## Summary
- map `tscircuit/checks` to the **Core Utility** category
- test that `tscircuit/checks` resolves to **Core Utility**

## Testing
- `bun test tests/getCategoryForPackage.test.ts`
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856d9d96a60832eabd160b2de863727