### PR TITLE
Default graph view shows all dependencies

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -105,7 +105,7 @@ async function fetchLastPackageJsonUpdate(
 
 export async function fetchDependencyGraphData(
   repoUrls: string[],
-  onlyPeerDependencies = true,
+  onlyPeerDependencies = false,
 ): Promise<GraphData> {
   const fetchedRepos: FetchedRepoInfo[] = await Promise.all(
     repoUrls.map(async (url) => {

--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -114,7 +114,7 @@ export function DependencyGraph() {
   const [error, setError] = useState<string | null>(null)
   const [userHasMovedNodes, setUserHasMovedNodes] = useState(false)
   const lastLayoutNodeIds = useRef<Set<string>>(new Set())
-  const [dependencyMode, setDependencyMode] = useState<"peer" | "all">("peer")
+  const [dependencyMode, setDependencyMode] = useState<"peer" | "all">("all")
   const [visibleCategories, setVisibleCategories] = useState<string[]>(
     ALL_CATEGORIES.filter(
       (c) => c !== "Downstream" && c !== "UI Packages",


### PR DESCRIPTION
## Summary
- show all dependencies by default instead of only peer dependencies

## Testing
- `bun test tests`
- `bun run format` *(fails: Script not found "format")*

------
https://chatgpt.com/codex/tasks/task_b_68583221cd08832eac2822b05013cf82