### PR TITLE
Implement node focus and opacity changes

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,26 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
+import type { Edge } from "reactflow"
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
+}
+
+export function getConnectedNodeIds(startId: string, edges: Edge[]): Set<string> {
+  const visited = new Set<string>([startId])
+  const queue = [startId]
+  while (queue.length) {
+    const id = queue.shift()!
+    edges.forEach((e) => {
+      if (e.source === id && !visited.has(e.target)) {
+        visited.add(e.target)
+        queue.push(e.target)
+      }
+      if (e.target === id && !visited.has(e.source)) {
+        visited.add(e.source)
+        queue.push(e.source)
+      }
+    })
+  }
+  return visited
 }

--- a/tests/getConnectedNodeIds.test.ts
+++ b/tests/getConnectedNodeIds.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from "bun:test"
+import type { Edge } from "reactflow"
+import { getConnectedNodeIds } from "../lib/utils"
+
+test("finds all nodes connected through edges", () => {
+  const edges: Edge[] = [
+    { id: "e1-2", source: "1", target: "2" },
+    { id: "e2-3", source: "2", target: "3" },
+  ]
+  const result = Array.from(getConnectedNodeIds("1", edges))
+  expect(result.sort()).toEqual(["1", "2", "3"])
+})
+
+test("returns only connected component", () => {
+  const edges: Edge[] = [
+    { id: "e1-2", source: "1", target: "2" },
+    { id: "e3-4", source: "3", target: "4" },
+  ]
+  const result = Array.from(getConnectedNodeIds("1", edges))
+  expect(result.sort()).toEqual(["1", "2"])
+})


### PR DESCRIPTION
## Summary
- add helper to compute connected nodes
- show Unfocus button when a node is focused
- fade nodes that aren't connected to the focused node
- expose onNodeClick to handle focusing
- test helper function

## Testing
- `bun test tests/getConnectedNodeIds.test.ts`
- `bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_685834fa78d4832ea09f0ba5d2f1d449