### PR TITLE
Add footprinter dependency

### DIFF
--- a/components/dependency-graph.tsx
+++ b/components/dependency-graph.tsx
@@ -55,6 +55,7 @@ const REPO_URLS = [
   "https://github.com/tscircuit/3d-viewer",
   "https://github.com/tscircuit/schematic-symbols",
   "https://github.com/tscircuit/jscad-fiber",
+  "https://github.com/tscircuit/footprinter",
   "https://github.com/tscircuit/jscad-electronics",
   "https://github.com/tscircuit/parts-engine",
   "https://github.com/tscircuit/cli",

--- a/lib/categories.ts
+++ b/lib/categories.ts
@@ -3,6 +3,7 @@ export const PACKAGE_CATEGORY_MAP: Record<string, string> = {
   "@tscircuit/props": "Specifications",
   "schematic-symbols": "Specifications",
   "@tscircuit/footprinter": "Specifications",
+  "tscircuit/footprinter": "Specifications",
   "jscad-fiber": "Specifications",
   "circuit-to-svg": "Core Utility",
   "jscad-electronics": "UI Packages",

--- a/tests/getCategoryForPackage.test.ts
+++ b/tests/getCategoryForPackage.test.ts
@@ -31,6 +31,12 @@ test("maps tscircuit to Packaged Bundles", () => {
   expect(getCategoryForPackage("tscircuit", "tscircuit")).toBe("Packaged Bundles")
 })
 
+test("maps tscircuit/footprinter to Specifications", () => {
+  expect(
+    getCategoryForPackage("tscircuit/footprinter", "tscircuit/footprinter"),
+  ).toBe("Specifications")
+})
+
 test("falls back to repo name", () => {
   expect(getCategoryForPackage("unknown", "@tscircuit/core")).toBe("Core")
 })


### PR DESCRIPTION
## Summary
- categorize `tscircuit/footprinter` as `Specifications`
- include `tscircuit/footprinter` in the dependency graph
- test mapping for the new dependency

## Testing
- `bun test tests/getCategoryForPackage.test.ts`
- `bun run format` *(fails: script not found)*

------
https://chatgpt.com/codex/tasks/task_b_686c0f611b64832e9d6281747b935a5f