### PR TITLE
Improve handling of non‑semver dependencies

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -179,7 +179,10 @@ export async function fetchDependencyGraphData(
           const latestAvailableVersion = latestVersionsMap.get(depName)!
 
           try {
-            if (!semver.satisfies(latestAvailableVersion, requiredVersionRange)) {
+            if (
+              semver.validRange(requiredVersionRange) &&
+              !semver.satisfies(latestAvailableVersion, requiredVersionRange)
+            ) {
               status = "STALE_DEPENDENCY"
               break
             }
@@ -232,16 +235,15 @@ export async function fetchDependencyGraphData(
             (r) => r.packageName === depName && !r.error,
           ) // Ensure source node (the dependency) exists and is valid
           if (sourceNodeExists) {
-            const requiredVersionRange = allDependencies[depName]
-            const latestAvailableVersion = latestVersionsMap.get(depName)!
-            const isLatest = semver.satisfies(
-              latestAvailableVersion,
-              requiredVersionRange,
-            )
-            const color = getEdgeColor(
-              requiredVersionRange,
-              latestAvailableVersion,
-            )
+              const requiredVersionRange = allDependencies[depName]
+              const latestAvailableVersion = latestVersionsMap.get(depName)!
+              const rangeValid = semver.validRange(requiredVersionRange)
+              const isLatest =
+                rangeValid &&
+                semver.satisfies(latestAvailableVersion, requiredVersionRange)
+              const color = rangeValid
+                ? getEdgeColor(requiredVersionRange, latestAvailableVersion)
+                : "#eab308"
             edges.push({
               id: `e-${depName}-${nodeId}`, // Edge from dependency to current repo
               source: depName, // Source is the dependency package name

--- a/lib/getEdgeColor.ts
+++ b/lib/getEdgeColor.ts
@@ -1,9 +1,14 @@
 import semver from "semver";
 
-export function getEdgeColor(requiredRange: string, latestVersion: string): string {
-  const latest = semver.parse(latestVersion);
-  const required = semver.minVersion(requiredRange);
-  if (!latest || !required) return "#eab308"; // default yellow/orange
+export function getEdgeColor(
+  requiredRange: string,
+  latestVersion: string,
+): string {
+  if (!semver.validRange(requiredRange) || !semver.valid(latestVersion)) {
+    return "#eab308"; // default yellow/orange
+  }
+  const latest = semver.parse(latestVersion)!;
+  const required = semver.minVersion(requiredRange)!;
 
   if (semver.eq(required, latest)) {
     return "#3b82f6"; // blue for latest

--- a/tests/getEdgeColor.test.ts
+++ b/tests/getEdgeColor.test.ts
@@ -20,3 +20,11 @@ test("returns red when minor version differs", () => {
 test("returns red when patch diff over 20", () => {
   expect(getEdgeColor("1.0.0", "1.0.30")).toBe("#ef4444");
 });
+
+test("handles non-semver range", () => {
+  const color = getEdgeColor(
+    "https://pkg.pr.new/tscircuit/eval/@tscircuit/eval@90b7d8c",
+    "1.0.0",
+  );
+  expect(color).toBe("#eab308");
+});


### PR DESCRIPTION
## Summary
- avoid semver parsing when the range is invalid
- guard against invalid ranges in `getEdgeColor`
- test for non-semver dependency ranges
- update semver to latest (no change)

## Testing
- `BUN_UPDATE_SNAPSHOTS=1 bun test tests`
- `bun run format` *(fails: Script not found)*

------
https://chatgpt.com/codex/tasks/task_b_6873fbfdf94c832eb8993daa78fb5826